### PR TITLE
optimistic auto bootstrap of cluster state for existing clusters

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -62,9 +62,10 @@ async function run() {
   await ux.print(`📦 Deploying ${ux.colors.white(STACK_REPO)}:${ux.colors.white(STACK_TAG)} to ${ux.colors.white(STACK_ENV)} cluster`)
   console.log('')
 
-  const BOOT_STATE = process?.env?.DEV_AWS_EKS_EC2_ASG_STATE || ''
-  const BOOT_CONFIG = JSON.parse(BOOT_STATE)
+  const STATE_PREFIX = `${STACK_ENV}_${STACK_TYPE}`.replace(/-/g, '_').toUpperCase()
   const BOOT_STATE_KEY = `${STACK_ENV}-${STACK_TYPE}`
+  const BOOT_STATE = process?.env[`${STATE_PREFIX}_STATE`] || ''
+  const BOOT_CONFIG = JSON.parse(BOOT_STATE)
 
   const cmd = Object.keys(BOOT_CONFIG[BOOT_STATE_KEY!])
     .find((k) => { return k.indexOf('ConfigCommand') > -1 })

--- a/src/stack/service.ts
+++ b/src/stack/service.ts
@@ -126,7 +126,7 @@ export default class Service extends cdk.Stack {
           secrets[index] = e
       }
     } catch(e) {
-      console.log('There was an error fetching secrets from the cluster vault:', e)
+      //console.log('There was an error fetching secrets from the cluster vault:', e)
     }
 
     const environment = Object.assign({
@@ -136,8 +136,8 @@ export default class Service extends cdk.Stack {
       DB_USER: CLUSTER_VAULT.secretValueFromJson('username').toString(),
       REDIS_HOST: this.redis?.cluster?.attrRedisEndpointAddress,
       REDIS_PORT: this.redis?.cluster?.attrRedisEndpointPort,
-      SQS_URL: this.mq?.queueUrl,
-      SQS_NAME: this.mq?.queueName,
+      MQ_URL: this.mq?.queueUrl,
+      MQ_NAME: this.mq?.queueName,
       CDN_URL: cf.distributionDomainName
     }, { ...secrets })
 

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -9,10 +9,7 @@ const OPTIONS = require('simple-argv')
 const STACK_TYPE = process.env.STACK_TYPE || 'aws-eks-ec2-asg';
 const STACK_TEAM = process.env.OPS_TEAM_NAME || 'private'
 
-
-
 async function init() {
-
 
   sdk.log(`🛠 Loading the ${ux.colors.white(STACK_TYPE)} stack for the ${ux.colors.white(STACK_TEAM)} team...`)
 


### PR DESCRIPTION
### overview
When running the setup or deploy flows for existing clusters, we need to optimistically boostrap state into the container, in order to ensure that CDK dependencies are met BEFORE they are synth'd deployed. This PR introduces some code that optimistically achieves this state and should fail silently for new setups. Separately, this PR also renames the MQ env var to generic protocol-agnostic name so that we can maintain consistency across stacks as long as there is a single MQ. 