### PR TITLE
Enhanced Deployment Prompting

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -123,7 +123,7 @@ async function run() {
   const getKubeConfig = await pexec('cat ~/.kube/config')
   process.env.KUBE_CONFIG = getKubeConfig.stdout;
 
-  await exec(`npm run cdk diff ${STACKS[STACK_ENV].join(' ')}`, {
+  await exec(`npm run cdk deploy ${STACKS[STACK_ENV].join(' ')}`, {
     env: { 
       ...process.env, 
       STACK_TYPE: STACK_TYPE, 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,6 +1,7 @@
 import util from 'util';
 import { ux, sdk } from '@cto.ai/sdk';
 import { exec as oexec } from 'child_process';
+import { stackEnvPrompt, stackRepoPrompt, stackTagPrompt } from './prompts';
 const pexec = util.promisify(oexec);
 
 async function run() {
@@ -10,32 +11,10 @@ async function run() {
 
   sdk.log(`🛠  Loading the ${ux.colors.white(STACK_TYPE)} stack for the ${ux.colors.white(STACK_TEAM)}...`)
 
-  const { STACK_ENV } = await ux.prompt<{
-    STACK_ENV: string
-  }>({
-      type: 'input',
-      name: 'STACK_ENV',
-      default: 'dev',
-      message: 'What is the name of the environment?'
-    })
+  const { STACK_ENV } = await stackEnvPrompt()
+  const { STACK_REPO } = await stackRepoPrompt()
+  const { STACK_TAG } = await stackTagPrompt()
 
-  const { STACK_REPO } = await ux.prompt<{
-    STACK_REPO: string
-  }>({
-      type: 'input',
-      name: 'STACK_REPO',
-      default: 'sample-expressjs-aws-eks-ec2-asg-cdk',
-      message: 'What is the name of the application repo?'
-    })
-
-  const { STACK_TAG } = await ux.prompt<{
-    STACK_TAG: string
-  }>({
-      type: 'input',
-      name: 'STACK_TAG',
-      default: 'main',
-      message: 'What is the name of the tag or branch?'
-    })
 
   const STACKS:any = {
     'dev': [`${STACK_REPO}-${STACK_TYPE}`, `${STACK_ENV}-${STACK_TYPE}`, `${STACK_ENV}-${STACK_REPO}-${STACK_TYPE}`],

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -33,61 +33,13 @@ async function run() {
 
   await ux.print(`\n🛠 Loading the latest tags for ${ux.colors.green(STACK_TYPE)} environment and ${ux.colors.green(STACK_REPO)} service...`)
 
-  async function retrieveCurrentlyDeployedImage(env: string, service: string): Promise<string> {
-    let ecsClusters: string[] = [];
-
-    try {
-      const commandOutput: Buffer = execSync(
-        `aws eks list-clusters --query "clusterArns[*]" --region $AWS_REGION`,
-        {
-          env: process.env
-        }
-      );
-
-      ecsClusters = JSON.parse(commandOutput.toString()) || [];
-    } catch (error) {
-      console.error("An error occurred while retrieving ECS clusters:", error);
-    }
-
-    let ecsCluster: string = ""
-    console.log("🚀 ~ file: deploy.ts:53 ~ retrieveCurrentlyDeployedImage ~ ecsClusters:", ecsClusters)
-
-    ecsClusters.forEach((clusterName: string) => {
-      const re = new RegExp(`cluster\/${env}`)
-      if (re.test(clusterName)) {
-        ecsCluster = clusterName
-      }
-    })
-
-    if (ecsCluster) {
-      console.log("🚀 ~ file: deploy.ts:62 ~ retrieveCurrentlyDeployedImage ~ ecsCluster:", ecsCluster)
-      // const ecsTasks: string[] = JSON.parse(execSync(
-      //   `aws ecs list-tasks --cluster ${ecsCluster} --service-name ${service} --query "taskArns" --region $AWS_REGION`,
-      //   {
-      //     env: process.env
-      //   }
-      // ).toString()) || [];
-
-      // for (const ecsTask of ecsTasks) {
-      //   try {
-      //     const image: string = execSync(
-      //       `aws ecs describe-tasks --region $AWS_REGION --query=tasks[0].containers[0].image --cluster ${ecsCluster} --tasks ${ecsTask}`,
-      //       {
-      //         env: process.env
-      //       }
-      //     ).toString().trim();
-
-      //     if (image) {
-      //       return image.replace(/.+:/, "").replace(/"/, "");
-      //     }
-      //   } catch (error) {
-      //     console.error("An error occurred while retrieving the image:", error);
-      //   }
-      // }
-    }
-
-    return ""
-  }
+  // TODO: Write function to return currently running image name and display it to the user.
+  //
+  // async function retrieveCurrentlyDeployedImage(env: string, service: string): Promise<string> {
+  //   return ""
+  // }
+  // const currentImage = await retrieveCurrentlyDeployedImage(STACK_ENV, STACK_REPO)
+  // await ux.print(`\n🖼️  Currently deployed image - ${ux.colors.green(currentImage)}\n`)
 
   const ecrImages: string[] = JSON.parse(execSync(
     `aws ecr describe-images --region=$AWS_REGION --repository-name ${ecrRepoName} --query "reverse(sort_by(imageDetails,& imagePushedAt))[*].imageTags[0]"`,
@@ -96,8 +48,6 @@ async function run() {
     }
   ).toString().trim()) || []
 
-  const currentImage = await retrieveCurrentlyDeployedImage(STACK_ENV, STACK_REPO)
-  await ux.print(`\n🖼️  Currently deployed image - ${ux.colors.green(currentImage)}\n`)
 
   const defaultImage = ecrImages.length ? ecrImages[0] : undefined
   const imageTagLimit = 20
@@ -124,7 +74,7 @@ async function run() {
   } else {
     ({ STACK_TAG } = await stackTagPrompt(
       ecrImages.slice(0, ecrImages.length < imageTagLimit ? ecrImages.length : imageTagLimit),
-      currentImage || defaultImage
+      defaultImage
     ))
   }
 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,6 +1,6 @@
 import util from 'util';
 import { ux, sdk } from '@cto.ai/sdk';
-import { exec as oexec } from 'child_process';
+import { exec as oexec, execSync } from 'child_process';
 import { stackEnvPrompt, stackRepoPrompt, stackTagPrompt } from './prompts';
 const pexec = util.promisify(oexec);
 
@@ -9,13 +9,126 @@ async function run() {
   const STACK_TYPE = process.env.STACK_TYPE || 'aws-eks-ec2-asg';
   const STACK_TEAM = process.env.OPS_TEAM_NAME || 'private'
 
-  sdk.log(`🛠  Loading the ${ux.colors.white(STACK_TYPE)} stack for the ${ux.colors.white(STACK_TEAM)}...`)
-
   const { STACK_ENV } = await stackEnvPrompt()
   const { STACK_REPO } = await stackRepoPrompt()
-  const { STACK_TAG } = await stackTagPrompt()
 
+  const ecrRepoName: string = `${STACK_REPO}-${STACK_TYPE}`
 
+  // Validate if the AWS Creds are set.
+  try {
+    const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+
+    if (accessKeyId && secretAccessKey) {
+      console.log('AWS credentials are set.');
+      // Proceed with the rest of the deployment logic
+    } else {
+      console.log('AWS credentials are not set.');
+      return;
+    }
+  } catch (error) {
+    console.error('Invalid credentials:', error);
+    return;
+  }
+
+  await ux.print(`\n🛠 Loading the latest tags for ${ux.colors.green(STACK_TYPE)} environment and ${ux.colors.green(STACK_REPO)} service...`)
+
+  async function retrieveCurrentlyDeployedImage(env: string, service: string): Promise<string> {
+    let ecsClusters: string[] = [];
+
+    try {
+      const commandOutput: Buffer = execSync(
+        `aws eks list-clusters --query "clusterArns[*]" --region $AWS_REGION`,
+        {
+          env: process.env
+        }
+      );
+
+      ecsClusters = JSON.parse(commandOutput.toString()) || [];
+    } catch (error) {
+      console.error("An error occurred while retrieving ECS clusters:", error);
+    }
+
+    let ecsCluster: string = ""
+    console.log("🚀 ~ file: deploy.ts:53 ~ retrieveCurrentlyDeployedImage ~ ecsClusters:", ecsClusters)
+
+    ecsClusters.forEach((clusterName: string) => {
+      const re = new RegExp(`cluster\/${env}`)
+      if (re.test(clusterName)) {
+        ecsCluster = clusterName
+      }
+    })
+
+    if (ecsCluster) {
+      console.log("🚀 ~ file: deploy.ts:62 ~ retrieveCurrentlyDeployedImage ~ ecsCluster:", ecsCluster)
+      // const ecsTasks: string[] = JSON.parse(execSync(
+      //   `aws ecs list-tasks --cluster ${ecsCluster} --service-name ${service} --query "taskArns" --region $AWS_REGION`,
+      //   {
+      //     env: process.env
+      //   }
+      // ).toString()) || [];
+
+      // for (const ecsTask of ecsTasks) {
+      //   try {
+      //     const image: string = execSync(
+      //       `aws ecs describe-tasks --region $AWS_REGION --query=tasks[0].containers[0].image --cluster ${ecsCluster} --tasks ${ecsTask}`,
+      //       {
+      //         env: process.env
+      //       }
+      //     ).toString().trim();
+
+      //     if (image) {
+      //       return image.replace(/.+:/, "").replace(/"/, "");
+      //     }
+      //   } catch (error) {
+      //     console.error("An error occurred while retrieving the image:", error);
+      //   }
+      // }
+    }
+
+    return ""
+  }
+
+  const ecrImages: string[] = JSON.parse(execSync(
+    `aws ecr describe-images --region=$AWS_REGION --repository-name ${ecrRepoName} --query "reverse(sort_by(imageDetails,& imagePushedAt))[*].imageTags[0]"`,
+    {
+      env: process.env
+    }
+  ).toString().trim()) || []
+
+  const currentImage = await retrieveCurrentlyDeployedImage(STACK_ENV, STACK_REPO)
+  await ux.print(`\n🖼️  Currently deployed image - ${ux.colors.green(currentImage)}\n`)
+
+  const defaultImage = ecrImages.length ? ecrImages[0] : undefined
+  const imageTagLimit = 20
+  let { STACK_TAG }: any = ''
+
+  const { STACK_TAG_CUSTOM } = await ux.prompt<{
+    STACK_TAG_CUSTOM: boolean
+  }>({
+    type: 'confirm',
+    name: 'STACK_TAG_CUSTOM',
+    default: false,
+    message: 'Do you want to deploy a custom image?'
+  });
+
+  if (STACK_TAG_CUSTOM){
+    ({ STACK_TAG } = await ux.prompt<{
+      STACK_TAG: string
+    }>({
+      type: 'input',
+      name: 'STACK_TAG',
+      message: 'What is the name of the tag or branch?',
+      allowEmpty: false
+    }))
+  } else {
+    ({ STACK_TAG } = await stackTagPrompt(
+      ecrImages.slice(0, ecrImages.length < imageTagLimit ? ecrImages.length : imageTagLimit),
+      currentImage || defaultImage
+    ))
+  }
+
+  await ux.print(`\n🛠 Loading the ${ux.colors.white(STACK_TYPE)} stack for the ${ux.colors.white(STACK_TEAM)}...\n`)
   const STACKS:any = {
     'dev': [`${STACK_REPO}-${STACK_TYPE}`, `${STACK_ENV}-${STACK_TYPE}`, `${STACK_ENV}-${STACK_REPO}-${STACK_TYPE}`],
     'stg': [`${STACK_REPO}-${STACK_TYPE}`, `${STACK_ENV}-${STACK_TYPE}`, `${STACK_ENV}-${STACK_REPO}-${STACK_TYPE}`],
@@ -60,7 +173,7 @@ async function run() {
   const getKubeConfig = await pexec('cat ~/.kube/config')
   process.env.KUBE_CONFIG = getKubeConfig.stdout;
 
-  await exec(`npm run cdk deploy ${STACKS[STACK_ENV].join(' ')}`, {
+  await exec(`npm run cdk diff ${STACKS[STACK_ENV].join(' ')}`, {
     env: { 
       ...process.env, 
       STACK_TYPE: STACK_TYPE, 

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -30,7 +30,8 @@ export function stackTagPrompt (tags: string[] = [], defaultValue?: string | num
         type: 'list',
         name: 'STACK_TAG',
         message: 'What is the name of the tag or branch?',
-        choices: tags
+        choices: tags,
+        default: defaultValue
     }
     : {
         type: 'input',

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,66 @@
+import {Answers, Questions, ux} from '@cto.ai/sdk';
+
+export function stackEnvPrompt () {
+    return ux.prompt < {
+        STACK_ENV: string
+    } > ({
+        type: 'list',
+        name: 'STACK_ENV',
+        choices: ['dev', 'stg', 'prd', 'all'],
+        default: 'dev',
+        message: 'What is the name of the environment?',
+    })
+}
+
+export function stackRepoPrompt () {
+    return ux.prompt < {
+        STACK_REPO: string
+    } > ({
+        type: 'list',
+        name: 'STACK_REPO',
+        choices: ['sample-expressjs-aws-eks-ec2-asg-cdk'],
+        default: 'sample-expressjs-aws-eks-ec2-asg-cdk',
+        message: 'What is the name of the application repo?',
+    })
+}
+
+export function stackTagPrompt (tags: string[] = [], defaultValue?: string | number) {
+    const questions: Questions = tags.length > 0
+    ? {
+        type: 'list',
+        name: 'STACK_TAG',
+        message: 'What is the name of the tag or branch?',
+        choices: tags
+    }
+    : {
+        type: 'input',
+        name: 'STACK_TAG',
+        message: 'What is the name of the tag or branch?',
+        allowEmpty: false
+    }
+    return ux.prompt < {
+        STACK_TAG: string
+    }>(questions)
+}
+
+export function secretValuePrompt () {
+    return ux.prompt < {
+        SECRET_VALUE: string
+    }>({
+        type: 'input',
+        name: 'SECRET_VALUE',
+        message: 'What is the value for the secret?',
+        allowEmpty: false
+    })
+}
+
+export function secretKeyPrompt () {
+    return ux.prompt < {
+        SECRET_NAME: string
+    }>({
+        type: 'input',
+        name: 'SECRET_NAME',
+        message: 'What is the key for the secret?',
+        allowEmpty: false
+    })
+}


### PR DESCRIPTION
### 📖 User Story
As a user, I want to be prompted to select the available options for environment, repo & tag during deployment STIC avoid typing or copy pasting values that are prone to typos which would create unusable infra

### 👍 Acceptance Criteria
GIVEN that a user wants to deploy via each workflows-sh stack

WHEN they are prompted for env, repo or tag

THEN they should be provided with drop down lists of the given envs, repo and images that are available to them for deployment

### ❓ Assumptions
We can reference an eisting implementation from aws-ecs-fargate

This should work for aws-eks* as it uses aws CLI

For DO, GKE we’d need alternative options

### 🏗️ Proposed Tasks
Port the aws-* solution back to the core stacks

FIgure out how to approach this with DO registry

Define how to approach this for the Pulumi stacks